### PR TITLE
CADC-15516 UI feature to flag inactive notebook sessions

### DIFF
--- a/public/dev/js/science_portal.js
+++ b/public/dev/js/science_portal.js
@@ -24,7 +24,7 @@
 
   // Idle session detection thresholds
   const IDLE_CPU_THRESHOLD = 0.5
-  const IDLE_HOURS_THRESHOLD = 8
+  const IDLE_HOURS_THRESHOLD = 48
   const IDLE_SESSION_MESSAGE = "This session is idle. Please consider closing to release resources and reduce energy consumption."
 
   /**

--- a/public/dev/js/science_portal.js
+++ b/public/dev/js/science_portal.js
@@ -22,6 +22,11 @@
     }
   })
 
+  // Idle session detection thresholds
+  const IDLE_CPU_THRESHOLD = 0.5
+  const IDLE_HOURS_THRESHOLD = 8
+  const IDLE_SESSION_MESSAGE = "This session is idle. Please consider closing to release resources and reduce energy consumption."
+
   /**
    * Controller for Science Portal UI. Contains event management backbone for the form, session list
    * and error handling. Behaviour of page is controlled from here, including showing and hiding
@@ -289,6 +294,19 @@
             }
           }
 
+          // Check idle status for running sessions
+          let isIdle = false
+          if (this.status === "Running" && this.startTime) {
+            const startDate = new Date(this.startTime)
+            const now = new Date()
+            const hoursElapsed = (now.getTime() - startDate.getTime()) / (1000 * 60 * 60)
+            let cpuUsage = parseFloat(this.cpuCoresInUse)
+            if (isNaN(cpuUsage)) { cpuUsage = 0 }
+            if (hoursElapsed > IDLE_HOURS_THRESHOLD && cpuUsage < IDLE_CPU_THRESHOLD) {
+              isIdle = true
+            }
+          }
+
           const nextSessionItem = {
             "id" : this.id,
             "name" : this.name,
@@ -312,7 +330,9 @@
             "renewHandler": handleRenewSession,
             "viewLogsURL": portalSessions.getViewLogsURL(this.id ),
             "viewEventsURL" : portalSessions.getViewEventsURL(this.id),
-            "isFixedResources": this.isFixedResources
+            "isFixedResources": this.isFixedResources,
+            "isIdle": isIdle,
+            "idleMessage": isIdle ? IDLE_SESSION_MESSAGE : ""
           }
 
           // Add to the list

--- a/src/App.js
+++ b/src/App.js
@@ -140,7 +140,8 @@ class SciencePortalApp extends React.Component {
       userInfo: {},
       theme: { },
       tabLabels: ["Public", "Advanced"],
-      fetchingStorageQuota: false
+      fetchingStorageQuota: false,
+      dismissedIdleAlerts: new Set()
     };
   }
 
@@ -153,6 +154,14 @@ class SciencePortalApp extends React.Component {
 
   updateSessionList(sessionDataObj) {
     this.setState({ sessionData: sessionDataObj });
+  }
+
+  handleDismissIdleAlert(sessionId) {
+    this.setState(prevState => {
+      const updated = new Set(prevState.dismissedIdleAlerts)
+      updated.add(sessionId)
+      return { dismissedIdleAlerts: updated }
+    })
   }
 
   updateModal(sModalData) {
@@ -387,7 +396,12 @@ class SciencePortalApp extends React.Component {
                 <>
                   {this.state.sessionData.sessData.map((mapObj) => (
                     <Col key={mapObj.id} className="sp-card-container">
-                      <SessionItem listType="list" sessData={mapObj} />
+                      <SessionItem
+                        listType="list"
+                        sessData={mapObj}
+                        isIdleDismissed={this.state.dismissedIdleAlerts.has(mapObj.id)}
+                        onDismissIdle={() => this.handleDismissIdleAlert(mapObj.id)}
+                      />
                     </Col>
                   ))}
                 </>

--- a/src/react/SessionItem.js
+++ b/src/react/SessionItem.js
@@ -9,6 +9,7 @@ import { faTrashAlt } from '@fortawesome/free-solid-svg-icons/faTrashAlt'
 import { faClock } from '@fortawesome/free-solid-svg-icons'
 import { faFlag } from '@fortawesome/free-solid-svg-icons'
 import { faFileLines } from '@fortawesome/free-solid-svg-icons'
+import { faTriangleExclamation } from '@fortawesome/free-solid-svg-icons'
 
 import './css/index.css';
 import './sp-session-list.css';
@@ -34,6 +35,10 @@ function SessionItem(props) {
   if (props.listType === "list") {
     if (props.sessData.status === "Running") {
       bgClass = "success"
+      if (props.sessData.isIdle === true) {
+        bgClass = "warning"
+        uberCSS = "sp-idle-card"
+      }
     } else if (props.sessData.status === "Pending") {
       // Set CSS and control for pending state, to block
       // cursor events and show progress cursor when
@@ -69,6 +74,19 @@ function SessionItem(props) {
       {props.listType === "list" &&
       <Card className={uberCSS}>
         <Card.Body className={cardCSS}>
+          {props.sessData.isIdle === true &&
+            <div className="sp-idle-triangle">
+              <OverlayTrigger
+                placement="right"
+                overlay={
+                  <Tooltip className="sp-idle-tooltip">
+                    {props.sessData.idleMessage}
+                  </Tooltip>
+                }>
+                <FontAwesomeIcon icon={faTriangleExclamation} className="sp-idle-triangle-icon"/>
+              </OverlayTrigger>
+            </div>
+          }
           <div className={connectCSS}
             onClick={props.sessData.connectHandler}
             data-connecturl={props.sessData.connectURL}>
@@ -154,6 +172,12 @@ function SessionItem(props) {
           {/*  End of the connectCSS area, used for event handling */}
           </div>
         </Card.Body>
+        {props.sessData.isIdle === true && props.isIdleDismissed !== true &&
+          <div className="sp-idle-banner">
+            <span className="sp-idle-banner-text">{props.sessData.idleMessage}</span>
+            <span className="sp-idle-banner-close" onClick={props.onDismissIdle}>&times;</span>
+          </div>
+        }
         <Card.Footer>
           <Row><Col>
             <div className="sp-card-button">

--- a/src/react/sp-session-list.css
+++ b/src/react/sp-session-list.css
@@ -665,9 +665,66 @@ a.nav-link {
   height: 35px;
 }
 
+/* Idle session indicator */
+.sp-idle-card.card {
+  border: 3px solid #e6a817;
+}
 
+.sp-idle-triangle {
+  position: absolute;
+  top: 8px;
+  left: 10px;
+  z-index: 1;
+}
 
+.sp-idle-triangle-icon {
+  color: #e6a817;
+  font-size: 16px;
+}
 
+.sp-idle-banner {
+  background-color: #fff3cd;
+  border-top: 1px solid #e6a817;
+  padding: 8px 15px;
+  font-size: 11px;
+  color: #664d03;
+  line-height: 1.4;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.sp-idle-banner-text {
+  flex: 1;
+}
+
+.sp-idle-banner-close {
+  cursor: pointer;
+  font-size: 16px;
+  font-weight: bold;
+  color: #664d03;
+  margin-left: 8px;
+  line-height: 1;
+}
+
+.sp-idle-banner-close:hover {
+  color: #000;
+}
+
+.sp-idle-tooltip > .tooltip-inner {
+  color: #000;
+  background-color: #fff;
+  border: 1px solid #e6a817;
+  opacity: 1;
+}
+
+.sp-idle-tooltip > .tooltip-arrow::before {
+  border-right-color: #e6a817;
+}
+
+.sp-idle-tooltip {
+  opacity: 1 !important;
+}
 
 
 

--- a/src/react/utilities/parseVospaceXML.test.js
+++ b/src/react/utilities/parseVospaceXML.test.js
@@ -1,7 +1,7 @@
 import { parseVospaceXML } from "./parseVospaceXML";
 import fs from "fs";
 import path from "path";
-import { DOMParser } from "xmldom";
+import { DOMParser } from "@xmldom/xmldom";
 
 test('parseVospaceXML parses storage XML correctly', () => {
     const xmlString = fs.readFileSync(path.join(__dirname, "mockFile.xml"), "utf8");

--- a/src/react/utilities/utils.js
+++ b/src/react/utilities/utils.js
@@ -141,6 +141,28 @@ const getProjectNames = (keyedProjects) => {
     );
 };
 
+/**
+ * Determines if a session should be flagged as idle based on age and CPU usage.
+ * @param {object} session - Session data with status, startTime, cpuCoresInUse
+ * @param {number} hoursThreshold - Minimum hours running to be considered idle
+ * @param {number} cpuThreshold - Maximum CPU cores in use to be considered idle
+ * @returns {boolean} true if session is idle
+ */
+const getSessionIdleStatus = (session, hoursThreshold, cpuThreshold) => {
+    if (!session || session.status !== "Running" || !session.startTime) {
+        return false
+    }
+
+    const startDate = new Date(session.startTime)
+    const now = new Date()
+    const hoursElapsed = (now.getTime() - startDate.getTime()) / (1000 * 60 * 60)
+
+    let cpuUsage = parseFloat(session.cpuCoresInUse)
+    if (isNaN(cpuUsage)) { cpuUsage = 0 }
+
+    return hoursElapsed > hoursThreshold && cpuUsage < cpuThreshold
+};
+
 module.exports = {
     getImagesByType,
     getImageProject,
@@ -149,5 +171,6 @@ module.exports = {
     getProjectImagesMap,
     getProjectNames,
     filterImagesByRegistry,
-    getUniqueRegistries
+    getUniqueRegistries,
+    getSessionIdleStatus
 };

--- a/src/react/utilities/utils.test.js
+++ b/src/react/utilities/utils.test.js
@@ -451,82 +451,84 @@ describe('Registry Utility Functions', () => {
 });
 
 describe('getSessionIdleStatus', () => {
-    const hoursThreshold = 48;
-    const cpuThreshold = 0.5;
+    const HOURS_THRESHOLD = 48;
+    const CPU_THRESHOLD = 0.5;
+    const OVER_THRESHOLD_HOURS = 72;
+    const UNDER_THRESHOLD_HOURS = 24;
 
     // Helper to create a startTime N hours ago
     const hoursAgo = (h) => new Date(Date.now() - h * 60 * 60 * 1000).toISOString();
 
     test('returns true for running session older than threshold with low CPU', () => {
-        const session = { status: "Running", startTime: hoursAgo(10), cpuCoresInUse: "0.1" };
-        expect(getSessionIdleStatus(session, hoursThreshold, cpuThreshold)).toBe(true);
+        const session = { status: "Running", startTime: hoursAgo(OVER_THRESHOLD_HOURS), cpuCoresInUse: "0.1" };
+        expect(getSessionIdleStatus(session, HOURS_THRESHOLD, CPU_THRESHOLD)).toBe(true);
     });
 
     test('returns false for running session younger than threshold', () => {
-        const session = { status: "Running", startTime: hoursAgo(2), cpuCoresInUse: "0.1" };
-        expect(getSessionIdleStatus(session, hoursThreshold, cpuThreshold)).toBe(false);
+        const session = { status: "Running", startTime: hoursAgo(UNDER_THRESHOLD_HOURS), cpuCoresInUse: "0.1" };
+        expect(getSessionIdleStatus(session, HOURS_THRESHOLD, CPU_THRESHOLD)).toBe(false);
     });
 
     test('returns false for running session with high CPU usage', () => {
-        const session = { status: "Running", startTime: hoursAgo(10), cpuCoresInUse: "2.5" };
-        expect(getSessionIdleStatus(session, hoursThreshold, cpuThreshold)).toBe(false);
+        const session = { status: "Running", startTime: hoursAgo(OVER_THRESHOLD_HOURS), cpuCoresInUse: "2.5" };
+        expect(getSessionIdleStatus(session, HOURS_THRESHOLD, CPU_THRESHOLD)).toBe(false);
     });
 
     test('returns false for non-Running sessions', () => {
         expect(getSessionIdleStatus(
-            { status: "Pending", startTime: hoursAgo(100), cpuCoresInUse: "0" },
-            hoursThreshold, cpuThreshold
+            { status: "Pending", startTime: hoursAgo(OVER_THRESHOLD_HOURS), cpuCoresInUse: "0" },
+            HOURS_THRESHOLD, CPU_THRESHOLD
         )).toBe(false);
 
         expect(getSessionIdleStatus(
-            { status: "Terminating", startTime: hoursAgo(100), cpuCoresInUse: "0" },
-            hoursThreshold, cpuThreshold
+            { status: "Terminating", startTime: hoursAgo(OVER_THRESHOLD_HOURS), cpuCoresInUse: "0" },
+            HOURS_THRESHOLD, CPU_THRESHOLD
         )).toBe(false);
     });
 
     test('treats null/undefined cpuCoresInUse as 0 (idle)', () => {
         expect(getSessionIdleStatus(
-            { status: "Running", startTime: hoursAgo(10), cpuCoresInUse: null },
-            hoursThreshold, cpuThreshold
+            { status: "Running", startTime: hoursAgo(OVER_THRESHOLD_HOURS), cpuCoresInUse: null },
+            HOURS_THRESHOLD, CPU_THRESHOLD
         )).toBe(true);
 
         expect(getSessionIdleStatus(
-            { status: "Running", startTime: hoursAgo(10) },
-            hoursThreshold, cpuThreshold
+            { status: "Running", startTime: hoursAgo(OVER_THRESHOLD_HOURS) },
+            HOURS_THRESHOLD, CPU_THRESHOLD
         )).toBe(true);
     });
 
     test('handles cpuCoresInUse as number', () => {
         expect(getSessionIdleStatus(
-            { status: "Running", startTime: hoursAgo(10), cpuCoresInUse: 0.3 },
-            hoursThreshold, cpuThreshold
+            { status: "Running", startTime: hoursAgo(OVER_THRESHOLD_HOURS), cpuCoresInUse: 0.3 },
+            HOURS_THRESHOLD, CPU_THRESHOLD
         )).toBe(true);
 
         expect(getSessionIdleStatus(
-            { status: "Running", startTime: hoursAgo(10), cpuCoresInUse: 1.0 },
-            hoursThreshold, cpuThreshold
+            { status: "Running", startTime: hoursAgo(OVER_THRESHOLD_HOURS), cpuCoresInUse: 1.0 },
+            HOURS_THRESHOLD, CPU_THRESHOLD
         )).toBe(false);
     });
 
     test('returns false for CPU exactly at threshold', () => {
-        const session = { status: "Running", startTime: hoursAgo(10), cpuCoresInUse: "0.5" };
-        expect(getSessionIdleStatus(session, hoursThreshold, cpuThreshold)).toBe(false);
+        const session = { status: "Running", startTime: hoursAgo(OVER_THRESHOLD_HOURS), cpuCoresInUse: "0.5" };
+        expect(getSessionIdleStatus(session, HOURS_THRESHOLD, CPU_THRESHOLD)).toBe(false);
     });
 
     test('returns false for null/undefined session', () => {
-        expect(getSessionIdleStatus(null, hoursThreshold, cpuThreshold)).toBe(false);
-        expect(getSessionIdleStatus(undefined, hoursThreshold, cpuThreshold)).toBe(false);
+        expect(getSessionIdleStatus(null, HOURS_THRESHOLD, CPU_THRESHOLD)).toBe(false);
+        expect(getSessionIdleStatus(undefined, HOURS_THRESHOLD, CPU_THRESHOLD)).toBe(false);
     });
 
     test('returns false when startTime is missing', () => {
         const session = { status: "Running", cpuCoresInUse: "0.1" };
-        expect(getSessionIdleStatus(session, hoursThreshold, cpuThreshold)).toBe(false);
+        expect(getSessionIdleStatus(session, HOURS_THRESHOLD, CPU_THRESHOLD)).toBe(false);
     });
 
     test('respects different threshold values', () => {
-        const session = { status: "Running", startTime: hoursAgo(50), cpuCoresInUse: "0.3" };
-        expect(getSessionIdleStatus(session, 48, 0.5)).toBe(true);
-        expect(getSessionIdleStatus(session, 72, 0.5)).toBe(false);
-        expect(getSessionIdleStatus(session, 48, 0.1)).toBe(false);
+        const session = { status: "Running", startTime: hoursAgo(OVER_THRESHOLD_HOURS), cpuCoresInUse: "0.3" };
+        expect(getSessionIdleStatus(session, HOURS_THRESHOLD, CPU_THRESHOLD)).toBe(true);
+        expect(getSessionIdleStatus(session, OVER_THRESHOLD_HOURS + 1, CPU_THRESHOLD)).toBe(false);
+        expect(getSessionIdleStatus(session, HOURS_THRESHOLD, 0.1)).toBe(false);
     });
 });

--- a/src/react/utilities/utils.test.js
+++ b/src/react/utilities/utils.test.js
@@ -1,4 +1,4 @@
-import { getImagesByType, getImageProject, getImageRegistry, getImagesNamesSorted, getProjectImagesMap, getProjectNames, filterImagesByRegistry, getUniqueRegistries } from './utils';
+import { getImagesByType, getImageProject, getImageRegistry, getImagesNamesSorted, getProjectImagesMap, getProjectNames, filterImagesByRegistry, getUniqueRegistries, getSessionIdleStatus } from './utils';
 import { imageResponse } from './testData';
 
 describe('Image List Processing Functions', () => {
@@ -447,5 +447,86 @@ describe('Registry Utility Functions', () => {
             ];
             expect(getUniqueRegistries(images)).toEqual(['images.canfar.net']);
         });
+    });
+});
+
+describe('getSessionIdleStatus', () => {
+    const hoursThreshold = 8;
+    const cpuThreshold = 0.5;
+
+    // Helper to create a startTime N hours ago
+    const hoursAgo = (h) => new Date(Date.now() - h * 60 * 60 * 1000).toISOString();
+
+    test('returns true for running session older than threshold with low CPU', () => {
+        const session = { status: "Running", startTime: hoursAgo(10), cpuCoresInUse: "0.1" };
+        expect(getSessionIdleStatus(session, hoursThreshold, cpuThreshold)).toBe(true);
+    });
+
+    test('returns false for running session younger than threshold', () => {
+        const session = { status: "Running", startTime: hoursAgo(2), cpuCoresInUse: "0.1" };
+        expect(getSessionIdleStatus(session, hoursThreshold, cpuThreshold)).toBe(false);
+    });
+
+    test('returns false for running session with high CPU usage', () => {
+        const session = { status: "Running", startTime: hoursAgo(10), cpuCoresInUse: "2.5" };
+        expect(getSessionIdleStatus(session, hoursThreshold, cpuThreshold)).toBe(false);
+    });
+
+    test('returns false for non-Running sessions', () => {
+        expect(getSessionIdleStatus(
+            { status: "Pending", startTime: hoursAgo(100), cpuCoresInUse: "0" },
+            hoursThreshold, cpuThreshold
+        )).toBe(false);
+
+        expect(getSessionIdleStatus(
+            { status: "Terminating", startTime: hoursAgo(100), cpuCoresInUse: "0" },
+            hoursThreshold, cpuThreshold
+        )).toBe(false);
+    });
+
+    test('treats null/undefined cpuCoresInUse as 0 (idle)', () => {
+        expect(getSessionIdleStatus(
+            { status: "Running", startTime: hoursAgo(10), cpuCoresInUse: null },
+            hoursThreshold, cpuThreshold
+        )).toBe(true);
+
+        expect(getSessionIdleStatus(
+            { status: "Running", startTime: hoursAgo(10) },
+            hoursThreshold, cpuThreshold
+        )).toBe(true);
+    });
+
+    test('handles cpuCoresInUse as number', () => {
+        expect(getSessionIdleStatus(
+            { status: "Running", startTime: hoursAgo(10), cpuCoresInUse: 0.3 },
+            hoursThreshold, cpuThreshold
+        )).toBe(true);
+
+        expect(getSessionIdleStatus(
+            { status: "Running", startTime: hoursAgo(10), cpuCoresInUse: 1.0 },
+            hoursThreshold, cpuThreshold
+        )).toBe(false);
+    });
+
+    test('returns false for CPU exactly at threshold', () => {
+        const session = { status: "Running", startTime: hoursAgo(10), cpuCoresInUse: "0.5" };
+        expect(getSessionIdleStatus(session, hoursThreshold, cpuThreshold)).toBe(false);
+    });
+
+    test('returns false for null/undefined session', () => {
+        expect(getSessionIdleStatus(null, hoursThreshold, cpuThreshold)).toBe(false);
+        expect(getSessionIdleStatus(undefined, hoursThreshold, cpuThreshold)).toBe(false);
+    });
+
+    test('returns false when startTime is missing', () => {
+        const session = { status: "Running", cpuCoresInUse: "0.1" };
+        expect(getSessionIdleStatus(session, hoursThreshold, cpuThreshold)).toBe(false);
+    });
+
+    test('respects different threshold values', () => {
+        const session = { status: "Running", startTime: hoursAgo(50), cpuCoresInUse: "0.3" };
+        expect(getSessionIdleStatus(session, 48, 0.5)).toBe(true);
+        expect(getSessionIdleStatus(session, 72, 0.5)).toBe(false);
+        expect(getSessionIdleStatus(session, 48, 0.1)).toBe(false);
     });
 });

--- a/src/react/utilities/utils.test.js
+++ b/src/react/utilities/utils.test.js
@@ -451,7 +451,7 @@ describe('Registry Utility Functions', () => {
 });
 
 describe('getSessionIdleStatus', () => {
-    const hoursThreshold = 8;
+    const hoursThreshold = 48;
     const cpuThreshold = 0.5;
 
     // Helper to create a startTime N hours ago


### PR DESCRIPTION
  Summary                                                 
                                                            
  - Adds idle session detection based on CPU usage and      
  session age (>48h running, <0.5 CPU cores in use)
  - Idle sessions display an amber card border, warning     
  badge, triangle icon with tooltip, and a dismissible      
  banner prompting users to release resources
  - Banner can be dismissed per-session and reappears on    
  page reload                                               
  - Adds getSessionIdleStatus utility function with full
  test coverage (10 tests)                                  
  - Fixes pre-existing xmldom import in                   
  parseVospaceXML.test.js                                   
                                                          
  Test plan                                                 
                                                          
  - Deploy and verify idle indicators appear on sessions    
  meeting criteria (>48h, <0.5 CPU cores)                 
  - Verify normal/active sessions show standard green badge 
  with no idle indicators                                   
  - Verify Pending sessions are not flagged
  - Verify banner dismiss persists through polling refreshes
   but resets on page reload                                
  - Verify triangle tooltip shows idle message on hover     
  - Run npx react-scripts test --watchAll=false — 49 tests  
  pass 