### PR TITLE
Align session and storage dashboard panels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@ node_modules
 /.pnp
 .pnp.js
 
+#AI Tools
+.cursor/
+.playwright*/
+
 # Testing
 /coverage
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,20 @@
+# Contributing
+
+## Commit messages
+
+Use [Conventional Commits](https://www.conventionalcommits.org/):
+
+`<type>(<optional scope>): <description>`
+
+- **Types** (common): `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`
+- **Scope**: optional, short, lowercase noun in parentheses (for example `home`, `api`, `auth`)
+- **Description**: imperative mood, lowercase, no trailing period; keep the first line around 72 characters when practical
+- **Breaking changes**: add `!` after the type or scope (`feat(api)!:`) or a `BREAKING CHANGE:` footer in the commit body
+
+Examples:
+
+- `fix(home): align session and storage widget heights`
+- `feat(api): add session renew endpoint`
+- `chore(deps): bump next to 15.5.10`
+
+Avoid vague messages such as "Update code" or "Fix bug".

--- a/src/app/implementation/activeSessionsWidget.tsx
+++ b/src/app/implementation/activeSessionsWidget.tsx
@@ -86,6 +86,9 @@ export function ActiveSessionsWidgetImpl({
         borderRadius: theme.shape.borderRadius,
         border: `1px solid ${theme.palette.divider}`,
         boxShadow: '0 1px 3px rgba(0,0,0,0.05)',
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
       }}
       component="div"
     >
@@ -130,7 +133,15 @@ export function ActiveSessionsWidgetImpl({
       />
 
       {/* Content - Session Cards */}
-      <Box sx={{ marginBottom: theme.spacing(2) }}>
+      <Box
+        sx={{
+          flex: 1,
+          minHeight: 0,
+          marginBottom: theme.spacing(2),
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
         {isLoading ? (
           // Show skeleton cards during loading
           effectiveLayout === 'column' ? (

--- a/src/app/implementation/userStorageWidget.tsx
+++ b/src/app/implementation/userStorageWidget.tsx
@@ -75,7 +75,6 @@ const StorageCard: React.FC<StorageCardProps> = ({ label, value, isLoading, isWa
   return (
     <Box
       sx={{
-        height: '100%',
         borderRadius: 2,
         backgroundColor: 'background.paper',
         border: `1px solid ${theme.palette.divider}`,
@@ -309,6 +308,9 @@ export const UserStorageWidgetImpl = React.forwardRef<HTMLDivElement, UserStorag
           border: `1px solid ${theme.palette.divider}`,
           boxShadow: '0 1px 3px rgba(0,0,0,0.05)',
           maxWidth: 600,
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
           // Better mobile padding
           [theme.breakpoints.down('sm')]: {
             padding: theme.spacing(1.5),
@@ -405,60 +407,70 @@ export const UserStorageWidgetImpl = React.forwardRef<HTMLDivElement, UserStorag
           />
         )}
 
-        {/* Storage Cards or Empty State */}
-        {!displayData && !currentLoading ? (
-          <Box
-            sx={{
-              textAlign: 'center',
-              py: 4,
-              color: theme.palette.text.secondary,
-            }}
-          >
-            <Typography variant="body2">{emptyMessage}</Typography>
-          </Box>
-        ) : (
-          <Box sx={{ mb: 2 }}>
-            <Grid container spacing={2} direction="column">
-              {cardData.map((card, index) => (
-                <Grid size={12} key={index}>
-                  <StorageCard
-                    label={card.label}
-                    value={card.value}
-                    isLoading={currentLoading}
-                    isWarning={card.isWarning}
-                  />
-                </Grid>
-              ))}
-            </Grid>
-          </Box>
-        )}
+        <Box
+          sx={{
+            flex: 1,
+            minHeight: 0,
+            display: 'flex',
+            flexDirection: 'column',
+          }}
+        >
+          {/* Storage Cards or Empty State */}
+          {!displayData && !currentLoading ? (
+            <Box
+              sx={{
+                textAlign: 'center',
+                py: 4,
+                color: theme.palette.text.secondary,
+              }}
+            >
+              <Typography variant="body2">{emptyMessage}</Typography>
+            </Box>
+          ) : (
+            <Box sx={{ mb: 2 }}>
+              <Grid container spacing={2} direction="column">
+                {cardData.map((card, index) => (
+                  <Grid size={12} key={index}>
+                    <StorageCard
+                      label={card.label}
+                      value={card.value}
+                      isLoading={currentLoading}
+                      isWarning={card.isWarning}
+                    />
+                  </Grid>
+                ))}
+              </Grid>
+            </Box>
+          )}
 
-        {/* Last Update Timestamp */}
-        {lastUpdate && !currentLoading && (
-          <Box
-            sx={{
-              textAlign: 'center',
-              mt: 2,
-              color: theme.palette.text.secondary,
-            }}
-          >
-            <Typography variant="caption" sx={{ fontSize: '10px' }}>
-              Last update:{' '}
-              <Typography
-                component="span"
-                variant="caption"
-                sx={{
-                  fontSize: '10px',
-                  fontWeight: 'bold',
-                  fontFamily: 'monospace',
-                  color: 'primary.500',
-                }}
-              >
-                {lastUpdate}
+          {/* Last Update Timestamp */}
+          {lastUpdate && !currentLoading && (
+            <Box
+              sx={{
+                textAlign: 'center',
+                mt: 'auto',
+                pt: 2,
+                color: theme.palette.text.secondary,
+              }}
+            >
+              <Typography variant="caption" sx={{ fontSize: '10px' }}>
+                Last update:{' '}
+                <Typography
+                  component="span"
+                  variant="caption"
+                  sx={{
+                    fontSize: '10px',
+                    fontWeight: 'bold',
+                    fontFamily: 'monospace',
+                    color: 'primary.500',
+                  }}
+                >
+                  {lastUpdate}
+                </Typography>
               </Typography>
-            </Typography>
-          </Box>
-        )}
+            </Box>
+          )}
+        </Box>
 
         {/* Help Popover */}
         {helpContent && (

--- a/src/app/implementation/userStorageWidget.tsx
+++ b/src/app/implementation/userStorageWidget.tsx
@@ -21,12 +21,37 @@ import {
   StorageCardData,
 } from '@/app/types/UserStorageWidgetProps';
 import { useApiRoutes } from '@/lib/hooks/useApiRoutes';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import updateLocale from 'dayjs/plugin/updateLocale';
+
+dayjs.extend(utc);
+dayjs.extend(relativeTime);
+dayjs.extend(updateLocale);
+dayjs.updateLocale('en', {
+  relativeTime: {
+    future: 'in %s',
+    past: '%s ago',
+    s: 'a few seconds',
+    m: 'a min',
+    mm: '%d mins',
+    h: 'an hr',
+    hh: '%d hrs',
+    d: 'a day',
+    dd: '%d days',
+    M: 'a month',
+    MM: '%d months',
+    y: 'a year',
+    yy: '%d years',
+  },
+});
 
 // Test data for development
 const TEST_DATA: StorageData = {
   size: 11281596360,
   quota: 200000000000,
-  date: 'Jun 11, 2025, 11:27:58 PM PDT',
+  date: '2025-06-12T06:27:58.000Z',
   usage: 94,
 };
 
@@ -48,17 +73,63 @@ const convertToFileSize = (bytes: number): string => {
   return `${size.toFixed(size < 10 ? 2 : 1)} ${units[u]}`;
 };
 
-const formatDateUTC = (dateString: string): string => {
-  if (!dateString) return 'Unknown';
-  try {
-    const date = new Date(dateString);
-    return date
-      .toISOString()
-      .replace('T', ' ')
-      .replace(/\.\d{3}Z$/, ' UTC');
-  } catch {
-    return 'Unknown';
+/**
+ * Parse storage API `date` as a UTC instant (VOSpace node date for used size / totals).
+ * Naive `YYYY-MM-DD …` values are treated as UTC wall time, not local.
+ */
+const parseStorageApiUtc = (raw: string): dayjs.Dayjs | null => {
+  const s = raw.trim();
+  if (!s) return null;
+
+  const utcLiteral = s.match(/^(\d{4}-\d{2}-\d{2})[ T](\d{2}:\d{2}:\d{2})(\.\d+)?\s*UTC$/i);
+  if (utcLiteral) {
+    const stamp = `${utcLiteral[1]} ${utcLiteral[2]}${utcLiteral[3] ?? ''}`;
+    const fmt = utcLiteral[3] ? 'YYYY-MM-DD HH:mm:ss.SSS' : 'YYYY-MM-DD HH:mm:ss';
+    const d = dayjs.utc(stamp, fmt);
+    return d.isValid() ? d : null;
   }
+
+  if (/[zZ]$|[+-]\d{2}:\d{2}$|[+-]\d{4}$/.test(s)) {
+    const d = dayjs(s);
+    return d.isValid() ? d.utc() : null;
+  }
+
+  const naive = s.match(/^(\d{4}-\d{2}-\d{2})([ T])(\d{2}:\d{2}:\d{2})(\.\d+)?$/);
+  if (naive) {
+    const stamp = `${naive[1]} ${naive[3]}${naive[4] ?? ''}`;
+    const fmt = naive[4] ? 'YYYY-MM-DD HH:mm:ss.SSS' : 'YYYY-MM-DD HH:mm:ss';
+    const d = dayjs.utc(stamp, fmt);
+    return d.isValid() ? d : null;
+  }
+
+  const loose = dayjs.utc(s);
+  if (loose.isValid()) return loose;
+
+  const localFallback = dayjs(s);
+  return localFallback.isValid() ? localFallback : null;
+};
+
+const formatStorageDateLocalDefault = (raw: string): string => {
+  const instant = parseStorageApiUtc(raw);
+  if (!instant) return 'Unknown';
+
+  return new Intl.DateTimeFormat(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+    timeZoneName: 'short',
+  }).format(instant.toDate());
+};
+
+/** Relative time since totals were last modified (API instant → browser “now”). */
+const formatRelativeStorageModified = (raw: string, nowMs: number): string => {
+  const instant = parseStorageApiUtc(raw);
+  if (!instant) return 'Unknown';
+  return instant.from(dayjs(nowMs));
 };
 
 // Storage Card Component
@@ -137,7 +208,7 @@ export const UserStorageWidgetImpl = React.forwardRef<HTMLDivElement, UserStorag
       progressPercentage = 0,
       warningThreshold = 90,
       emptyMessage = 'No storage data available',
-      dateFormatter = formatDateUTC,
+      dateFormatter = formatStorageDateLocalDefault,
       fileSizeFormatter = convertToFileSize,
       testMode = false,
     },
@@ -149,6 +220,7 @@ export const UserStorageWidgetImpl = React.forwardRef<HTMLDivElement, UserStorag
     const [internalLoading, setInternalLoading] = useState(false);
     const [internalError, setInternalError] = useState<string | undefined>();
     const [helpAnchorEl, setHelpAnchorEl] = useState<HTMLElement | null>(null);
+    const [relativeNowMs, setRelativeNowMs] = useState(() => Date.now());
 
     // Use external data if provided, otherwise use internal data or test data
     const currentData = useMemo(() => {
@@ -200,9 +272,13 @@ export const UserStorageWidgetImpl = React.forwardRef<HTMLDivElement, UserStorag
       }));
     }, [displayData, cardConfigs, warningThreshold]);
 
-    const lastUpdate = useMemo(() => {
+    const sizeTotalsModifiedAbsolute = useMemo(() => {
       return displayData?.date ? dateFormatter(displayData.date) : null;
     }, [displayData?.date, dateFormatter]);
+
+    const sizeTotalsModifiedRelative = useMemo(() => {
+      return displayData?.date ? formatRelativeStorageModified(displayData.date, relativeNowMs) : null;
+    }, [displayData?.date, relativeNowMs]);
 
     // Internal fetch function
     const fetchStorageData = useCallback(async () => {
@@ -294,6 +370,19 @@ export const UserStorageWidgetImpl = React.forwardRef<HTMLDivElement, UserStorag
         setInternalError(undefined);
       }
     }, [isAuthenticated]);
+
+    useEffect(() => {
+      if (!displayData?.date) return;
+      setRelativeNowMs(Date.now());
+
+      const intervalId = window.setInterval(() => {
+        setRelativeNowMs(Date.now());
+      }, 60000);
+
+      return () => {
+        window.clearInterval(intervalId);
+      };
+    }, [displayData?.date]);
 
     return (
       <Paper
@@ -443,33 +532,44 @@ export const UserStorageWidgetImpl = React.forwardRef<HTMLDivElement, UserStorag
             </Box>
           )}
 
-          {/* Last Update Timestamp */}
-          {lastUpdate && !currentLoading && (
-            <Box
-              sx={{
-                textAlign: 'center',
-                mt: 'auto',
-                pt: 2,
-                color: theme.palette.text.secondary,
-              }}
-            >
-              <Typography variant="caption" sx={{ fontSize: '10px' }}>
-                Last update:{' '}
-                <Typography
-                  component="span"
-                  variant="caption"
-                  sx={{
-                    fontSize: '10px',
-                    fontWeight: 'bold',
-                    fontFamily: 'monospace',
-                    color: 'primary.500',
-                  }}
+          {/* When used size / quota totals last changed (VOSpace node mtime), not “last polled” */}
+          {sizeTotalsModifiedRelative &&
+            sizeTotalsModifiedRelative !== 'Unknown' &&
+            !currentLoading && (
+              <Box
+                sx={{
+                  textAlign: 'center',
+                  mt: 'auto',
+                  pt: 2,
+                  color: theme.palette.text.secondary,
+                }}
+              >
+                <Tooltip
+                  title={
+                    sizeTotalsModifiedAbsolute
+                      ? `${sizeTotalsModifiedAbsolute}`
+                      : 'Unknown'
+                  }
+                  arrow
                 >
-                  {lastUpdate}
-                </Typography>
-              </Typography>
-            </Box>
-          )}
+                  <Typography variant="caption" sx={{ fontSize: '10px' }}>
+                    Modified{' '}
+                    <Typography
+                      component="span"
+                      variant="caption"
+                      sx={{
+                        fontSize: '10px',
+                        fontWeight: 'bold',
+                        color: 'primary.500',
+                      }}
+                    >
+                      {sizeTotalsModifiedRelative}
+                    </Typography>
+                    {'.'}
+                  </Typography>
+                </Tooltip>
+              </Box>
+            )}
         </Box>
 
         {/* Help Popover */}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -381,21 +381,32 @@ export default function SciencePortalPage() {
               sx={{
                 flex: { xs: 1, lg: '0 0 80%' },
                 minWidth: 0, // Prevent flex item from overflowing
+                display: 'flex',
+                flexDirection: 'column',
               }}
             >
-              <ActiveSessionsWidget
-                sessions={activeSessions}
-                operatingSessionIds={operatingSessionIds}
-                pollingSessionId={pollingSessionId}
-                layout="responsive"
-                isLoading={isLoadingSessions}
-                onRefresh={handleSessionsRefresh}
-                emptyMessage={
-                  showLoggedOutCopy
-                    ? 'Sign in to see your active sessions. Use the Login button in the header.'
-                    : 'No active sessions'
-                }
-              />
+              <Box
+                sx={{
+                  flex: { xs: 'none', lg: 1 },
+                  minHeight: { lg: 0 },
+                  display: 'flex',
+                  flexDirection: 'column',
+                }}
+              >
+                <ActiveSessionsWidget
+                  sessions={activeSessions}
+                  operatingSessionIds={operatingSessionIds}
+                  pollingSessionId={pollingSessionId}
+                  layout="responsive"
+                  isLoading={isLoadingSessions}
+                  onRefresh={handleSessionsRefresh}
+                  emptyMessage={
+                    showLoggedOutCopy
+                      ? 'Sign in to see your active sessions. Use the Login button in the header.'
+                      : 'No active sessions'
+                  }
+                />
+              </Box>
             </Box>
 
             {/* UserStorageWidget - 20% width on large screens */}
@@ -404,18 +415,29 @@ export default function SciencePortalPage() {
                 flex: { xs: 1, lg: '0 0 20%' },
                 minWidth: 0, // Prevent flex item from overflowing
                 px: { xs: 1, sm: 2 }, // Add horizontal padding
+                display: 'flex',
+                flexDirection: 'column',
               }}
             >
-              <UserStorageWidget
-                isAuthenticated={isAuthenticated}
-                name={authStatus?.user?.username || ''}
-                isLoading={isLoadingUserStorage}
-                emptyMessage={
-                  showLoggedOutCopy
-                    ? 'Sign in to view your storage usage. Use the Login button in the header.'
-                    : 'No storage data available'
-                }
-              />
+              <Box
+                sx={{
+                  flex: { xs: 'none', lg: 1 },
+                  minHeight: { lg: 0 },
+                  display: 'flex',
+                  flexDirection: 'column',
+                }}
+              >
+                <UserStorageWidget
+                  isAuthenticated={isAuthenticated}
+                  name={authStatus?.user?.username || ''}
+                  isLoading={isLoadingUserStorage}
+                  emptyMessage={
+                    showLoggedOutCopy
+                      ? 'Sign in to view your storage usage. Use the Login button in the header.'
+                      : 'No storage data available'
+                  }
+                />
+              </Box>
             </Box>
           </Box>
         </Container>


### PR DESCRIPTION
## Summary

- Match **Active Sessions** and **User Home Storage** panel heights on large screens (flex column layout, full-height papers, storage footer pinned with `mt: auto`).
- A more humanized report of the last time storage info was updated, e.g. Modified X ago, absolute timestamp still available as a hover.
- Add **CONTRIBUTING.md** with Conventional Commits guidance for commit messages.

## Screenshot
<img width="1581" height="489" alt="image" src="https://github.com/user-attachments/assets/879fbf90-e258-436a-a620-746447c19b62" />

<img width="261" height="349" alt="image" src="https://github.com/user-attachments/assets/6651e348-5930-4a99-bdf9-06ae8ede94ed" />

<img width="273" height="375" alt="image" src="https://github.com/user-attachments/assets/a6b7c15b-240c-44a6-ac73-1973bc2c6020" />

## Test plan

- [x] `npm run build`